### PR TITLE
change: update local dev and tools sections to uv-based setup

### DIFF
--- a/docs/source/local_dev_setup.md
+++ b/docs/source/local_dev_setup.md
@@ -27,13 +27,13 @@ Here are the steps to install everything you will need to work with the _base_ c
 2. Install [uv](https://docs.astral.sh/uv/) based on the
    [uv install instructions](https://docs.astral.sh/uv/getting-started/installation/).
    We suggest to use the standalone installer if you don't have a specific setup that requires another method.
-
    - Check if everything is working with `uv --version`. To install a python version and create and
      activate an environment in any folder you want to have it, use the following:
      ```bash
      uv venv -p 3.12 .venv  # creates a virtual env based on python 3.12 in the .venv folder
      source .venv/bin/activate  # activate the new environment (use `deactivate` to deactivate)
      ```
+   - For a quick ref on how to use `uv` check the [](./tools.md) section.
 3. Install [nvm](https://github.com/nvm-sh/nvm) and the latest LTS version of Node.js:
    - ```bash
      curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash

--- a/docs/source/local_dev_setup.md
+++ b/docs/source/local_dev_setup.md
@@ -19,35 +19,21 @@ Here are the steps to install everything you will need to work with the _base_ c
      ```
    - ```{note}
      Disclaimer: if you really solely work on frontend code or only on backend code, you could either
-     leave out the following step 2 (pyenv) or 3 (nvm), to not clutter your system. But we suggest
+     leave out the following step 2 (uv) or 3 (nvm), to not clutter your system. But we suggest
      installing both, so you are ready also to run frontend or backend code on your machine any time -
      which will be necessary for testing at some point, when you do not want or cannot rely on the
      dev containers.
      ```
-2. Install pyenv (using the [pyenv-installer](https://github.com/pyenv/pyenv-installer)):
+2. Install [uv](https://docs.astral.sh/uv/) based on the
+   [uv install instructions](https://docs.astral.sh/uv/getting-started/installation/).
+   We suggest to use the standalone installer if you don't have a specific setup that requires another method.
 
-   - ```bash
-     curl https://pyenv.run | bash
-
-     echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
-     echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-     echo 'eval "$(pyenv init -)"' >> ~/.bashrc
-     echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc
-
-     source ~/.bashrc
-     ```
-
-   - Check if everything is working with `pyenv -v`. To install a python version and create and
-     activate an environment use the following:
+   - Check if everything is working with `uv --version`. To install a python version and create and
+     activate an environment in any folder you want to have it, use the following:
      ```bash
-     pyenv install 3.11  # (re)installs python 3.11
-     pyenv virtualenv 3.11 project-test  # creates a virtual env based on python 3.11
-     pyenv activate project-test  # activates the new environment, use pyenv deactivate to deactivate
+     uv venv -p 3.12 .venv  # creates a virtual env based on python 3.12 in the .venv folder
+     source .venv/bin/activate  # activate the new environment (use `deactivate` to deactivate)
      ```
-   - For more info on how to use `pyenv`, check [TODO: create public section from our internal docs on pyenv]
-   - If you are using a different shell, or need more finetuning, check the pyenv docs section to
-     [Set up your shell environment for Pyenv](https://github.com/pyenv/pyenv#set-up-your-shell-environment-for-pyenv)
-
 3. Install [nvm](https://github.com/nvm-sh/nvm) and the latest LTS version of Node.js:
    - ```bash
      curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
@@ -114,8 +100,8 @@ This is described in the project's documentation.
 The general procedure looks like this:
 
 1. Clone the required repositories
-2. Create how many environments you need (recommended: one environment per project) with `pyenv` for the backend stuff
-   or use `nvm` to activate the proper node environment for frontend stuff.
+2. Create how many environments you need (recommended: one environment per project) with `uv` for the backend stuff
+   and `nvm` to activate the proper node environment for frontend stuff.
    - See the [](./tools.md) section for a quick reference on how to use pyenv.
 3. Follow the steps on in either the README.md in the repo root folder or the requirements.md and install.md files
    in the docs/source/ (or in older projects only /docs) folder.

--- a/docs/source/local_dev_setup.md
+++ b/docs/source/local_dev_setup.md
@@ -6,8 +6,7 @@ This is the basic setup guide for a fresh Linux client system, to
 have everything ready in order to work on our different base applications.
 This should work on most Debian-based distributions. It was specifically tested on:
 
-- Debian 11.4 & 12.4
-- Ubuntu 22.04 LTS
+- Debian 13 (Trixie)
 
 Here are the steps to install everything you will need to work with the _base_ codebase:
 
@@ -27,12 +26,7 @@ Here are the steps to install everything you will need to work with the _base_ c
 2. Install [uv](https://docs.astral.sh/uv/) based on the
    [uv install instructions](https://docs.astral.sh/uv/getting-started/installation/).
    We suggest to use the standalone installer if you don't have a specific setup that requires another method.
-   - Check if everything is working with `uv --version`. To install a python version and create and
-     activate an environment in any folder you want to have it, use the following:
-     ```bash
-     uv venv -p 3.12 .venv  # creates a virtual env based on python 3.12 in the .venv folder
-     source .venv/bin/activate  # activate the new environment (use `deactivate` to deactivate)
-     ```
+   - Check if everything is working with `uv` and `uv --version`.
    - For a quick ref on how to use `uv` check the [](./tools.md) section.
 3. Install [nvm](https://github.com/nvm-sh/nvm) and the latest LTS version of Node.js:
    - ```bash

--- a/docs/source/tools.md
+++ b/docs/source/tools.md
@@ -2,11 +2,60 @@
 
 ## Python
 
+### uv
+
+`uv` is our main tool to manage Python versions and virtual environments. Check out the
+[uv docs](https://docs.astral.sh/uv/) and its Getting Started guide. Here is just a
+short quick-ref on how to use it in our projects.
+
+#### Installation
+
+Download and run the installation script (Linux & macOS):
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Everything should be up and running. Test it with `uv --version`. For different
+installation procedures check out the [installation section](https://docs.astral.sh/uv/getting-started/installation/)
+in the official uv docs. If you don't have a specific requirement for a different
+source/package, we suggest using the standalone installer.
+
+#### Usage
+
+Here are just a few commands we regularly use, for more detailed infos check out the
+[official docs](https://docs.astral.sh/uv/), especially the _First Steps_ and _Features_
+sections.
+
+```bash
+# check available python versions and which you have already installed
+uv python list
+
+# create a new Python 3.12 virtual environment in the .venv folder
+uv venv -p 3.12 .venv
+
+# activate the new environment
+source .venv/bin/activate
+
+# sync all packages in your venv with what is listed in requirements.txt
+uv pip sync requirements.txt
+
+# deactivate you virtual environment (to switch back to the systems main python environment)
+deactivate
+
+# install pre-commit
+uv tool install pre-commit --with pre-commit-uv
+```
+
 ### pyenv and pyenv-virtualenv
 
 Here we outline some notes on installation and usage of pyenv and virtual Python environments
-with pyenv-virtualenv. If you have followed the setup in [](./local_dev_setup.md), you already
-have pyenv and pyenv-virtualenv set up, so you can skip the _Installation_ section below.
+with pyenv-virtualenv.
+
+```{warning}
+In our newer setup we are using `uv`, but some older projects still might be documented
+based on a pyenv setup. This section is kept here, if you still want to use `pyenv` for
+some specific projects. But generally we do advise switching to `uv`.
+```
 
 #### Installation
 


### PR DESCRIPTION
Just updating the local dev setup and tooling to reflect our new uv-based setup.
Still left the pyenv related section in the tools chapter for now with a deprecation warning.