### PR TITLE
Document that we decided to always make merge commits

### DIFF
--- a/docs/source/dev_guide.md
+++ b/docs/source/dev_guide.md
@@ -247,6 +247,10 @@ for working on bugfixes that should be reviewed before being merged into `develo
 
 When merging a git-flow branch, **always create a merge commit, even if a fast-forward merge is possible, and even if your branch only has one commit**.
 
+Check the [](./local_dev_setup.md) section for instructions on how to configure `git merge` and the `git-flow` extension to do the right thing by default here.
+
+Alternatively, you can simply use the `--no-ff` flag on `git-flow` subcommands as well as vanilla `git merge` - for example, `git flow feature finish --no-ff` and `git merge --no-ff feature/add-shrubberies` would both always create a merge commit.
+
 #### Commit Guidelines
 
 The cardinal rule for creating good commits is to ensure there is only one "logical change" per commit. There are many reasons why this is an important rule:

--- a/docs/source/dev_guide.md
+++ b/docs/source/dev_guide.md
@@ -245,6 +245,8 @@ The main branch should be `main` instead of `master`.
 Additional to the established git-flow branches, `fix` branches can be used similar to `feature` branches,
 for working on bugfixes that should be reviewed before being merged into `develop` again.
 
+When merging a git-flow branch, **always create a merge commit, even if a fast-forward merge is possible, and even if your branch only has one commit**.
+
 #### Commit Guidelines
 
 The cardinal rule for creating good commits is to ensure there is only one "logical change" per commit. There are many reasons why this is an important rule:

--- a/docs/source/local_dev_setup.md
+++ b/docs/source/local_dev_setup.md
@@ -71,6 +71,9 @@ Here are the steps to install everything you will need to work with the _base_ c
      git config --global gitflow.feature.finish.no-ff "yes"
      git config --global gitflow.bugfix.finish.no-ff "yes"
      ```
+     ```{note}
+     Be aware that this will change your git config for all repositories - if you're a one-time contributor, you may want to run these commands only in the repository you want to contribute to, and leave out the `--global` flag.
+     ```
      Alternatively you can also directly edit the _.gitconfig_ file in your home directory (e.g. with
      `editor ~/.gitconfig`). Here is a template including some handy shortcuts for git:
      ```ini

--- a/docs/source/local_dev_setup.md
+++ b/docs/source/local_dev_setup.md
@@ -76,6 +76,11 @@ Here are the steps to install everything you will need to work with the _base_ c
      ```{note}
      Be aware that this will change your git config for all repositories - if you're a one-time contributor, you may want to run these commands only in the repository you want to contribute to, and leave out the `--global` flag.
      ```
+     ```{note}
+     Setting `pull.ff` isn't necessary, but restores the default behavior of `git pull` -- when setting `merge.ff` to `false`, just pulling new changes from a remote would create a merge commit, which is probably not what you want.
+
+     You may wish to not touch the settings for the internal `git` commands at all, and simply always use `git-flow` for dealing with your branches.
+     ```
      Alternatively you can also directly edit the _.gitconfig_ file in your home directory (e.g. with
      `editor ~/.gitconfig`). Here is a template including some handy shortcuts for git:
      ```ini

--- a/docs/source/local_dev_setup.md
+++ b/docs/source/local_dev_setup.md
@@ -63,13 +63,13 @@ Here are the steps to install everything you will need to work with the _base_ c
      git config --global init.defaultBranch
      git config --global merge.ff
      git config --global pull.ff
-     # update the settings
+     # update the settings (careful: applies to all repos!)
      git config --global user.name "Ms. Robot"
      git config --global user.email "ro@example.org"
      git config --global init.defaultBranch "main"
      git config --global merge.ff "false"
      git config --global pull.ff "true"
-     # set settings for the git-flow extension
+     # set settings for the git-flow extension (careful: applies to all repos!)
      git config --global gitflow.feature.finish.no-ff "true"
      git config --global gitflow.bugfix.finish.no-ff "true"
      ```

--- a/docs/source/local_dev_setup.md
+++ b/docs/source/local_dev_setup.md
@@ -70,8 +70,8 @@ Here are the steps to install everything you will need to work with the _base_ c
      git config --global merge.ff "false"
      git config --global pull.ff "true"
      # set settings for the git-flow extension
-     git config --global gitflow.feature.finish.no-ff "yes"
-     git config --global gitflow.bugfix.finish.no-ff "yes"
+     git config --global gitflow.feature.finish.no-ff "true"
+     git config --global gitflow.bugfix.finish.no-ff "true"
      ```
      ```{note}
      Be aware that this will change your git config for all repositories - if you're a one-time contributor, you may want to run these commands only in the repository you want to contribute to, and leave out the `--global` flag.
@@ -102,9 +102,9 @@ Here are the steps to install everything you will need to work with the _base_ c
      [init]
          defaultBranch = main
      [gitflow "feature.finish"]
-        no-ff = yes
+        no-ff = true
      [gitflow "bugfix.finish"]
-        no-ff = yes
+        no-ff = true
      [merge]
         ff = false
      ```

--- a/docs/source/local_dev_setup.md
+++ b/docs/source/local_dev_setup.md
@@ -62,11 +62,13 @@ Here are the steps to install everything you will need to work with the _base_ c
      git config --global user.email
      git config --global init.defaultBranch
      git config --global merge.ff
+     git config --global pull.ff
      # update the settings
      git config --global user.name "Ms. Robot"
      git config --global user.email "ro@example.org"
      git config --global init.defaultBranch "main"
      git config --global merge.ff "false"
+     git config --global pull.ff "true"
      # set settings for the git-flow extension
      git config --global gitflow.feature.finish.no-ff "yes"
      git config --global gitflow.bugfix.finish.no-ff "yes"

--- a/docs/source/local_dev_setup.md
+++ b/docs/source/local_dev_setup.md
@@ -108,7 +108,7 @@ Here are the steps to install everything you will need to work with the _base_ c
      [merge]
         ff = false
      [pull]
-        ff = false
+        ff = true
      ```
 
 Now you have a basic setup, except for an IDE you might want to use to work on code.

--- a/docs/source/local_dev_setup.md
+++ b/docs/source/local_dev_setup.md
@@ -107,6 +107,8 @@ Here are the steps to install everything you will need to work with the _base_ c
         no-ff = true
      [merge]
         ff = false
+     [pull]
+        ff = false
      ```
 
 Now you have a basic setup, except for an IDE you might want to use to work on code.

--- a/docs/source/local_dev_setup.md
+++ b/docs/source/local_dev_setup.md
@@ -53,7 +53,7 @@ Here are the steps to install everything you will need to work with the _base_ c
      - You should at least update your **user name** and **email** to what you would like to show up in the published commits.
      - Our **default branch is `main`**, which might not be the case with older git versions.
      - We follow the **`git-flow` branching model**. Check the [Git section of the dev guide](./dev_guide.md#git) for more details and a recommended git extension.
-     - **Merge commits** are **mandatory** when finishing a branch, **even if a fast-forward merge is possible, and even if there is only one commit in the branch**, so you might want to change the default behavior of `git merge` to always make a merge commit.
+     - **Merge commits** are **mandatory** when finishing a branch, **even if a fast-forward merge is possible, and even if there is only one commit in the branch**, so you might want to change the default behavior of `git merge` and the `git-flow` extension (if installed) to always make a merge commit.
 
      Here is how to check and update the corresponding settings:
      ```bash

--- a/docs/source/local_dev_setup.md
+++ b/docs/source/local_dev_setup.md
@@ -49,18 +49,27 @@ Here are the steps to install everything you will need to work with the _base_ c
      to the group `docker`, e.g. with `sudo usermod -a -G docker myusername`. Start a new
      terminal session afterward, so that the group info is updated in the environment.
 5. Set up git
-   - Before committing, make sure to check/update your git configuration. You should at least update your user name
-     and email to what you would like to show up in the published commits. Also our default branch is `main`, which
-     might not be the case with older git versions. Here is how to check and update them:
+   - Before committing, make sure to check/update your git configuration:
+     - You should at least update your **user name** and **email** to what you would like to show up in the published commits.
+     - Our **default branch is `main`**, which might not be the case with older git versions.
+     - We follow the **`git-flow` branching model**. Check the [Git section of the dev guide](./dev_guide.md#git) for more details and a recommended git extension.
+     - **Merge commits** are **mandatory** when finishing a branch, **even if a fast-forward merge is possible, and even if there is only one commit in the branch**, so you might want to change the default behavior of `git merge` to always make a merge commit.
+
+     Here is how to check and update the corresponding settings:
      ```bash
      # check your git config
      git config --global user.name
      git config --global user.email
      git config --global init.defaultBranch
+     git config --global merge.ff
      # update the settings
      git config --global user.name "Ms. Robot"
      git config --global user.email "ro@example.org"
      git config --global init.defaultBranch "main"
+     git config --global merge.ff "false"
+     # set settings for the git-flow extension
+     git config --global gitflow.feature.finish.no-ff "yes"
+     git config --global gitflow.bugfix.finish.no-ff "yes"
      ```
      Alternatively you can also directly edit the _.gitconfig_ file in your home directory (e.g. with
      `editor ~/.gitconfig`). Here is a template including some handy shortcuts for git:
@@ -82,6 +91,12 @@ Here are the steps to install everything you will need to work with the _base_ c
          editor = vim
      [init]
          defaultBranch = main
+     [gitflow "feature.finish"]
+        no-ff = yes
+     [gitflow "bugfix.finish"]
+        no-ff = yes
+     [merge]
+        ff = false
      ```
 
 Now you have a basic setup, except for an IDE you might want to use to work on code.

--- a/docs/source/local_dev_setup.md
+++ b/docs/source/local_dev_setup.md
@@ -52,7 +52,7 @@ Here are the steps to install everything you will need to work with the _base_ c
    - Before committing, make sure to check/update your git configuration:
      - You should at least update your **user name** and **email** to what you would like to show up in the published commits.
      - Our **default branch is `main`**, which might not be the case with older git versions.
-     - We follow the **`git-flow` branching model**. Check the [Git section of the dev guide](./dev_guide.md#git) for more details and a recommended git extension.
+     - We follow the **`git-flow` branching model**. Check the [Git section of the Development Guide](./dev_guide.md#git) for more details and a recommended git extension.
      - **Merge commits** are **mandatory** when finishing a branch, **even if a fast-forward merge is possible, and even if there is only one commit in the branch**, so you might want to change the default behavior of `git merge` and the `git-flow` extension (if installed) to always make a merge commit.
 
      Here is how to check and update the corresponding settings:

--- a/docs/source/local_dev_setup.md
+++ b/docs/source/local_dev_setup.md
@@ -73,7 +73,7 @@ Here are the steps to install everything you will need to work with the _base_ c
      git config --global gitflow.feature.finish.no-ff "true"
      git config --global gitflow.bugfix.finish.no-ff "true"
      ```
-     ```{note}
+     ```{warning}
      Be aware that this will change your git config for all repositories - if you're a one-time contributor, you may want to run these commands only in the repository you want to contribute to, and leave out the `--global` flag.
      ```
      ```{note}


### PR DESCRIPTION
It recently came up that there was a team decision to always create merge commits when merging branches.

This PR documents that and provides instructions to configure git to do the right thing for this workflow by default.

After pushing the first version of this, I realized that setting `merge.ff false` has a side effect: `git pull` will also create merge commits instead of fast-forwarding. This is probably not desired, so I also added instructions to restore the default behavior of `git pull`.